### PR TITLE
Fix double arrows appearing on modals on mobile

### DIFF
--- a/src/styles/itemModal.scss
+++ b/src/styles/itemModal.scss
@@ -20,7 +20,7 @@ $mobilewidth: 710px;
   @media (max-width: $mobilewidth) {
     &-prev, &-next {width: 40px; height: 100px; line-height: 100px; margin-top: -50px;
       font-size: 2.5rem; text-align: center; opacity: 1;
-      .material-icons {display: none;}
+      svg {display: none;}
       &:before {content: ""; width: 0; height: 0; border: transparent 20px solid; position: absolute;
         top: 0; bottom: 0; margin: auto;
       }


### PR DESCRIPTION
Fixes #193 

It seems that the original idea was to show larger arrows on mobile and hide the carets shown on larger screens. For some reason the icon's class was changed and therefore we were showing both the large arrow and the carets. The fix is to hide the caret's svgs on mobile

## Screenshot:

![deploy-preview-294--landscapeapp netlify com_cncf_selected=concourse](https://user-images.githubusercontent.com/16135423/63251032-3224b100-c26d-11e9-8da9-d54ca0fc569d.png)
