### PR TITLE
#269 Add option for non-open source projects in landscape.yml

### DIFF
--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -108,13 +108,15 @@ tree.map(function(node) {
       return null;
     };
     const getLicense = function() {
-      if (!node.github_data) {
-        if (node.repo_url) {
-          return 'Unknown License';
-        }
+      if ((node.hasOwnProperty('open_source') && !node.open_source) || !node.repo_url) {
         return 'NotOpenSource';
       }
-      return node.github_data.license;
+
+      if (node.github_data) {
+        return node.github_data.license;
+      }
+
+      return 'Unknown License';
     }
     const getAmount = function() {
       if (node.yahoo_finance_data) {
@@ -154,6 +156,9 @@ tree.map(function(node) {
       return {relation: false, isSubsidiaryProject: false};
     })();
 
+    if (node.repo_url) {
+      console.log(node.repo_url, getLicense())
+    }
 
     items.push({...node,
       project: node.project,

--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -156,10 +156,6 @@ tree.map(function(node) {
       return {relation: false, isSubsidiaryProject: false};
     })();
 
-    if (node.repo_url) {
-      console.log(node.repo_url, getLicense())
-    }
-
     items.push({...node,
       project: node.project,
       member: node.membership_data.member,

--- a/tools/validateLandscapeKeys.js
+++ b/tools/validateLandscapeKeys.js
@@ -20,7 +20,8 @@ const allowedKeys = [
   'branch',
   'project',
   'url_for_bestpractices',
-  'enduser'
+  'enduser',
+  'open_source'
 ];
 
 const categoryKeys = [


### PR DESCRIPTION
Implements #269 

Adding `open_source: false` to `landscape.yml` will force the project not to be open source.