### PR TITLE
If open_source is set to 'true' when there is no repo_url, have it as…

### DIFF
--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -108,7 +108,7 @@ tree.map(function(node) {
       return null;
     };
     const getLicense = function() {
-      if (node.hasOwnProperty('open_source') && node.open_source) && !node.repo_url) {
+      if (node.hasOwnProperty('open_source') && node.open_source && !node.repo_url) {
         return 'Other';
       }
       


### PR DESCRIPTION
… an 'Other' Open Source license

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>