### PR TITLE
Improvements to fetching data from github API

### DIFF
--- a/tools/githubDates.js
+++ b/tools/githubDates.js
@@ -105,10 +105,8 @@ const getCommitsLastPagePath = async (repo, branchSha) => {
 export async function getRepoStartDate({repo, branch}) {
   const branchSha = await getBranchSha(repo, branch);
   const commitsLastPagePath = await getCommitsLastPagePath(repo, branchSha);
-
-  return await makeApiRequest({ path: commitsLastPagePath }).then((commits) => {
-    const lastCommit = commits[commits.length - 1];
-    const commitLink = (new URL(lastCommit.html_url)).pathname;
-    return { date: lastCommit.commit.author.date, commitLink: commitLink };
-  });
+  const commits = await makeApiRequest({ path: commitsLastPagePath })
+  const lastCommit = commits[commits.length - 1];
+  const commitLink = (new URL(lastCommit.html_url)).pathname;
+  return { date: lastCommit.commit.author.date, commitLink: commitLink };
 }

--- a/tools/githubDates.js
+++ b/tools/githubDates.js
@@ -147,8 +147,9 @@ export async function getRepoLatestDate({repo, branch}) {
   }
 }
 
-const getBranchSha = (repo, branch) => {
-  return makeApiRequest({ path: `/repos/${repo}/branches/${branch}` }).then(({commit}) => commit.sha );
+const getBranchSha = async (repo, branch) => {
+  const { commit } = await makeApiRequest({ path: `/repos/${repo}/branches/${branch}` });
+  return commit.sha;
 }
 
 const getUrlFromLinkHeader = (link, rel) => {
@@ -160,18 +161,16 @@ const getUrlFromLinkHeader = (link, rel) => {
   }
 }
 
-const getCommitsLastPagePath = (repo, branchSha) => {
+const getCommitsLastPagePath = async (repo, branchSha) => {
   const path = `/repos/${repo}/commits?sha=${branchSha}`;
 
-  return makeApiRequest({ path, method: 'HEAD' })
-    .then(({link}) => {
-      const url = getUrlFromLinkHeader(link, 'last');
-      if (!url) {
-        return path
-      }
-      const { pathname, search } = new URL(url);
-      return pathname + search;
-    });
+  const { link } = await makeApiRequest({ path, method: 'HEAD' });
+  const url = getUrlFromLinkHeader(link, 'last');
+  if (!url) {
+    return path;
+  }
+  const { pathname, search } = new URL(url);
+  return pathname + search;
 }
 
 export async function getRepoStartDate({repo, branch}) {

--- a/tools/githubDates.js
+++ b/tools/githubDates.js
@@ -60,22 +60,10 @@ async function readGithubStats({repo, branch}) {
   }
 }
 export async function getReleaseDate({repo}) {
-  const url = `https://api.github.com/repos/${repo}/releases?access_token=${process.env.GITHUB_KEY}`;
-  try {
-    const releases = await rp({
-      uri: url,
-      followRedirect: true,
-      timeout: 10 * 1000,
-      headers: {
-        'User-agent': 'CNCF'
-      },
-      json: true
-    });
-    if (releases.length > 0) {
-      return releases[0].published_at;
-    }
-  } catch(e) {
-    throw e;
+  const releases = await makeApiRequest({ path: `/repos/${repo}/releases` });
+
+  if (releases.length > 0) {
+    return releases[0].published_at;
   }
 }
 

--- a/tools/githubDates.js
+++ b/tools/githubDates.js
@@ -42,9 +42,9 @@ async function readGithubStats({repo, branch}) {
   }
 }
 export async function getReleaseDate({repo}) {
-  var url = `https://api.github.com/repos/${repo}/releases/latest?access_token=${process.env.GITHUB_KEY}`;
+  const url = `https://api.github.com/repos/${repo}/releases?access_token=${process.env.GITHUB_KEY}`;
   try {
-    var releaseInfo = await rp({
+    const releases = await rp({
       uri: url,
       followRedirect: true,
       timeout: 10 * 1000,
@@ -53,11 +53,10 @@ export async function getReleaseDate({repo}) {
       },
       json: true
     });
-    return releaseInfo.published_at;
-  } catch(e) {
-    if (e.statusCode === 404) {
-      return null;
+    if (releases.length > 0) {
+      return releases[0].published_at;
     }
+  } catch(e) {
     throw e;
   }
 }

--- a/tools/githubDates.js
+++ b/tools/githubDates.js
@@ -78,65 +78,6 @@ export async function getReleaseDate({repo}) {
     throw e;
   }
 }
-async function getCommitDate(link) {
-  var url = `https://github.com${link}`;
-  var response = await rp({
-    uri: url,
-    followRedirect: true,
-    timeout: 10 * 1000,
-    simple: true
-  });
-  const dom = new JSDOM(response);
-  const doc = dom.window.document;
-  // console.info(doc.innerText, doc.text);
-  const time = doc.querySelector('[datetime]').getAttribute('datetime');
-  // console.info(time);
-  return time;
-}
-async function getPageStats({base, offset}) {
-  var response = await rp({
-    uri: `${base}+${offset}`,
-    followRedirect: true,
-    timeout: 10 * 1000,
-    simple: true
-  });
-  const dom = new JSDOM(response);
-  const doc = dom.window.document;
-  return await getPageInfo(doc);
-}
-
-async function getPageInfo(doc) {
-  const firstCommitLink = doc.querySelector('.commits-list-item a.sha');
-  if (!firstCommitLink) {
-    return null;
-  }
-  const firstHref = firstCommitLink.href;
-  const lastCommitLinks = doc.querySelectorAll('.commits-list-item a.sha');
-  const lastCommitLink = lastCommitLinks[lastCommitLinks.length - 1];
-  const lastHref = lastCommitLink.href;
-  const nextPageLink = Array.from(doc.querySelectorAll('.paginate-container a')).filter(function(x) {
-    return x.text === 'Older';
-  })[0];
-  const nextPageHref = nextPageLink ? nextPageLink.href : null;
-  return {
-    firstHref,
-    lastHref,
-    nextPageHref
-  };
-}
-
-async function promiseBinarySearch(low, high, fn) {
-  var mid = low + Math.floor((high - low) / 2);
-  let scoreMid = await fn(mid);
-  if (scoreMid === 0) {
-    return await promiseBinarySearch(mid, high, fn);
-  }
-  if (scoreMid === 2) {
-    return await promiseBinarySearch(low, mid, fn);
-  }
-  return mid;
-}
-
 
 export async function getRepoLatestDate({repo, branch}) {
   const info = await readGithubStats({repo, branch});
@@ -183,5 +124,3 @@ export async function getRepoStartDate({repo, branch}) {
     return { date: lastCommit.commit.author.date, commitLink: commitLink };
   });
 }
-// getRepoStartDate({repo: 'rails/rails'}).then(console.info).catch(console.info);
-// getRepoLatestDate({repo: 'theforeman/foreman', branch: 'develop'}).then(console.info).catch(console.info);


### PR DESCRIPTION
Fixes hanging when fetching data about https://github.com/gentoo/gentoo

* Use Github API to find a repo's first commit, instead of crawling Github UI.
* Find latest release by querying  `https://api.github.com/repos/${repo_name}/releases` and getting the first item on the list. This avoids getting a `404` when calling  `https://api.github.com/repos/${repo_name}/releases/latest`