### PR TITLE
Set npm loglevel to silent; closes #277

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+loglevel="silent"


### PR DESCRIPTION
Generated output by `npm install`

```bash
$ npm install

[fsevents] Success: "/Users/jordi/workspace/landscapeapp/node_modules/fsevents/lib/binding/Release/node-v67-darwin-x64/fse.node" is installed via remote
info sharp Using cached /Users/jordi/.npm/_libvips/libvips-8.7.4-darwin-x64.tar.gz
Downloading Chromium r674921 - 108.3 Mb [====================] 100% 0.0s
Cached binary found at /Users/jordi/.npm/node-sass/4.12.0/darwin-x64-67_binding.node
(node:24735) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 SIGINT listeners added. Use emitter.setMaxListeners() to increase limit
Binary found at /Users/jordi/workspace/landscapeapp/node_modules/node-sass/vendor/darwin-x64-67/binding.node
Testing binary
Binary is fine
added 2100 packages from 1076 contributors and audited 1749750 packages in 83.119s
found 28986 vulnerabilities (28985 high, 1 critical)
  run `npm audit fix` to fix them, or `npm audit` for details
```