### PR TITLE
Fix mobile zooming; Fix #345

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -7,6 +7,7 @@ import { Switch, Route } from 'react-router-dom';
 import { MainFullscreenLandscapeContainer, ExtraFullscreenLandscapeContainer, ThirdFullscreenLandscapeContainer } from "./BigPicture";
 import HomePageContainer from './HomePageContainer';
 import NotFoundPage from './NotFoundPage';
+import { isZoomedIn } from "../utils/browserZoom";
 import settings from 'project/settings.yml';
 const mainSettings = settings.big_picture.main;
 const extraSettings = settings.big_picture.extra;
@@ -21,9 +22,26 @@ window.prefix = prefix;
 // version of hot reloading won't hot reload a stateless
 // component at the top-level.
 class App extends React.Component {
+  state = {
+    isZoomed: false
+  }
+
+  componentDidMount () {
+    this.checkZoomedIn();
+    window.addEventListener("touchend", this.checkZoomedIn);
+  }
+
+  componentWillUnmount () {
+    window.removeEventListener("touchend", this.checkZoomedIn);
+  }
+
+  checkZoomedIn = () => {
+    this.setState({ isZoomed: isZoomedIn() })
+  }
+
   render() {
     return (
-      <div>
+      <div className={this.state.isZoomed ? "zoomed-in" : ""}>
         <CssBaseline />
         <Switch>
           <Route exact path={`/${prefix}`} component={HomePageContainer} />

--- a/src/components/CustomAutoSizer.js
+++ b/src/components/CustomAutoSizer.js
@@ -4,8 +4,7 @@ import { isZoomedIn } from "../utils/browserZoom";
 
 class AutoSizer extends React.PureComponent {
   state = {
-    height: this.props.defaultHeight || 0,
-    zoomedIn: false
+    height: this.props.defaultHeight || 0
   };
 
   componentDidMount() {

--- a/src/components/CustomAutoSizer.js
+++ b/src/components/CustomAutoSizer.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from "react-redux";
+import { isZoomedIn } from "../utils/browserZoom";
 
 class AutoSizer extends React.PureComponent {
   state = {
@@ -25,14 +26,13 @@ class AutoSizer extends React.PureComponent {
       // See issue #41
       this._onResize();
       window.addEventListener("resize", this._onResize);
-      window.addEventListener("touchend", this.onPossiblyZoomed);
-      this.setState({ zoomedIn: this.isZoomedIn() });
+      window.addEventListener("touchend", this.checkedZoomedIn);
     }
   }
 
   componentWillUnmount() {
     window.removeEventListener("resize", this._onResize);
-    window.removeEventListener("touchend", this.onPossiblyZoomed);
+    window.removeEventListener("touchend", this.checkedZoomedIn);
   }
 
   componentDidUpdate (prevProps) {
@@ -41,19 +41,14 @@ class AutoSizer extends React.PureComponent {
     }
   }
 
-  isZoomedIn = () => {
-    const scale = window.visualViewport ? visualViewport.scale : screen.width / window.innerWidth;
-    return scale > 1;
-  }
-
   render() {
     const { children } = this.props;
-    const { height, zoomedIn } = this.state;
+    const { height } = this.state;
 
     // Outer div should not force width/height since that may prevent containers from shrinking.
     // Inner component should overflow and use calculated width/height.
     // See issue #68 for more information.
-    const childParams = { height, zoomedIn };
+    const childParams = { height };
 
     return (
       <div
@@ -67,11 +62,9 @@ class AutoSizer extends React.PureComponent {
     );
   }
 
-  onPossiblyZoomed = (e) => {
+  checkedZoomedIn = (e) => {
     const windowHeight = window.innerHeight;
-    const zoomedIn = this.isZoomedIn();
-    this.setState({ zoomedIn }, this._onResize);
-    console.log(zoomedIn)
+    this._onResize();
 
     for (let i = 1; i < 11; i++) {
       const timeout = i * 50;
@@ -87,7 +80,7 @@ class AutoSizer extends React.PureComponent {
   _onResize = () => {
     if (this._parentNode) {
       const height = this._autoSizer.clientHeight + window.innerHeight - document.body.offsetHeight;
-      const zoomedIn = this.isZoomedIn();
+      const zoomedIn = isZoomedIn();
       this.setState({ height: zoomedIn ? 'auto' : height, zoomedIn });
     }
   };

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -207,8 +207,8 @@ const HomePage = ({isEmbed, mainContentMode, ready, hasSelectedItem, filtersVisi
             </div>
             { isBigPicture &&
             <AutoSizer>
-              {({ height, zoomedIn }) => (
-                <div className={`landscape-wrapper ${zoomedIn ? 'zoomed-in' : ''}`} style={{height: height}}>
+              {({ height }) => (
+                <div className="landscape-wrapper" style={{height: height}}>
                   { mainContentMode === mainSettings.url && <MainLandscapeContentContainer /> }
                   { mainContentMode === extraSettings.url && <ExtraLandscapeContentContainer /> }
                   { mainContentMode === thirdSettings.url && <ThirdLandscapeContentContainer /> }

--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -207,13 +207,11 @@ const HomePage = ({isEmbed, mainContentMode, ready, hasSelectedItem, filtersVisi
             </div>
             { isBigPicture &&
             <AutoSizer>
-              {({ height }) => (
-                <div className='landscape-wrapper' style={{height: height}}>
-                  <div style={{width: '100%', height: '100%', position: 'relative', overflow: 'scroll', padding: 10}}>
-                    { mainContentMode === mainSettings.url && <MainLandscapeContentContainer /> }
-                    { mainContentMode === extraSettings.url && <ExtraLandscapeContentContainer /> }
-                    { mainContentMode === thirdSettings.url && <ThirdLandscapeContentContainer /> }
-                  </div>
+              {({ height, zoomedIn }) => (
+                <div className={`landscape-wrapper ${zoomedIn ? 'zoomed-in' : ''}`} style={{height: height}}>
+                  { mainContentMode === mainSettings.url && <MainLandscapeContentContainer /> }
+                  { mainContentMode === extraSettings.url && <ExtraLandscapeContentContainer /> }
+                  { mainContentMode === thirdSettings.url && <ThirdLandscapeContentContainer /> }
                 </div>
               )}
             </AutoSizer>

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -11,10 +11,8 @@ $lg-screen: 992px;
 $xl-screen: 1200px;
 
 html {-webkit-text-size-adjust: 100%;}
-html.big-picture {
-  &, & body {
-    overflow: scroll;
-  }
+.big-picture .zoomed-in {
+  overflow: scroll;
 }
 
 body {background-color:#F4F4f4 !important; font-family: Arial, Helvetica, sans-serif;}
@@ -419,7 +417,7 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='rgb(124,170,1
   padding: 10px;
 }
 
-.landscape-wrapper.zoomed-in {
+.zoomed-in .landscape-wrapper {
   display: inline-block;
   width: auto;
   overflow: visible;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -87,6 +87,13 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
   }
 }
 
+.fullscreen {
+  .summary,
+  .disclaimer {
+    display: none;
+  }
+}
+
 .header_container {
   z-index: 2;
   height: 70px;

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -185,6 +185,7 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
 }
 
 .app {
+  position: relative; 
   .sidebar-show {
     display: none;
   }
@@ -543,6 +544,16 @@ html:not(.big-picture) .right-buttons {
     top: initial;
     bottom: -35px;
     width: 100%;
+  }
+
+  .zoomed-in .right-buttons > div {
+    float: left;
+    margin-left: 0;
+    margin-right: 2px;
+  }
+
+  .zoomed-in .right-buttons .tweet-button {
+    margin-left: 7px;
   }
 }
 

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -49,7 +49,6 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
     color: $blue;
     &:hover {transition: all 0.1s; color: $blue-hover;}
   }
-
 }
 
 .disclaimer {
@@ -91,7 +90,7 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
   .header {
     padding: 20px;
     .landscape-logo {
-      position: fixed;
+      position: absolute;
       top: 0;
       left: 0;
       padding: 20px;
@@ -110,7 +109,7 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
     }
     .landscapeapp-logo {display: block; width: 170px; height: 30px; position: absolute; top: 20px; right: 20px; z-index: 3;
       img {width: 100%;}
-      @media (max-width: $lg-screen) {position: fixed;}
+      @media (max-width: $lg-screen) {position: absolute;}
       @media (max-width: $md-screen) {width: 155px;}
     }
     .info {margin-top: -32px; padding-left: 20px; height: auto;}
@@ -181,7 +180,7 @@ a {text-decoration: none; transition: all 0.5s; color: $blue;
   @media (max-width: $lg-screen) {
     .sidebar-show {
       display: block;
-      position: fixed;
+      position: absolute;
       top: 11px;
       left: 0;
       z-index: 3;
@@ -399,9 +398,18 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='rgb(124,170,1
 }
 
 .landscape-wrapper {
-  width: 100%;
   position: relative;
   background: rgb(134,175,188);
+  width: 100%;
+  height: 100%;
+  overflow: scroll;
+  padding: 10px;
+}
+
+.landscape-wrapper.zoomed-in {
+  display: inline-block;
+  width: auto;
+  overflow: visible;
 }
 
 .cards-section {

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -11,6 +11,12 @@ $lg-screen: 992px;
 $xl-screen: 1200px;
 
 html {-webkit-text-size-adjust: 100%;}
+html.big-picture {
+  &, & body {
+    overflow: scroll;
+  }
+}
+
 body {background-color:#F4F4f4 !important; font-family: Arial, Helvetica, sans-serif;}
 body.popup {background-color:transparent !important;}
 

--- a/src/utils/browserZoom.js
+++ b/src/utils/browserZoom.js
@@ -1,0 +1,6 @@
+const isZoomedIn = () => {
+  const scale = window.visualViewport ? visualViewport.scale : screen.width / window.innerWidth;
+  return scale > 1;
+}
+
+export { isZoomedIn };


### PR DESCRIPTION
## Fix zooming issues on mobile (and tablet)

When user zooms in on mobile (or tablet), change the landscape to have auto width and height (as opposed to fixed width and height) and move the scrolling to the outer page. 

![mobile-zoom](https://user-images.githubusercontent.com/16135423/65428441-aaeece00-de14-11e9-8e4e-c6546befbb5c.gif)
