### PR TITLE
add grouping by a primary language, close #445

### DIFF
--- a/src/components/InternalLink.js
+++ b/src/components/InternalLink.js
@@ -11,7 +11,7 @@ const InternalLink = ({to, children, onClick, className, ...other}) => {
       onClick();
     };
   }
-  if (isEmbed || isGoogle) {
+  if (isEmbed || isGoogle || !to) {
     return <span className={`${className}`} {...other}>{children}</span>;
   } else {
     return <NavLink className={`${className}  nav-link`} {...other} to={to}>{children}</NavLink>

--- a/src/components/ItemDialogContent.js
+++ b/src/components/ItemDialogContent.js
@@ -212,13 +212,15 @@ const chart = function(itemInfo) {
 
   const legend = <div style={{position: 'absolute', width: 170, left: 0, top: 0, marginTop: -5, marginBottom: 5, fontSize: '0.8em'  }}>
     {languages.map(function(language) {
+      const url = language.name === 'Other' ? null : filtersToUrl({grouping: 'language', filters: {language: language.name }});
       return <div style = {{
         position: 'relative',
         marginTop: 2,
         height: 12
       }} >
         <div style={{display: 'inline-block', position: 'absolute', height: 12, width: 12, background: language.color, top: 2, marginRight: 4}} />
-        <div style={{display: 'inline-block', position: 'relative', width: 125, left: 16,  whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}>{ getLegendText(language) }</div>
+        <div style={{display: 'inline-block', position: 'relative', width: 125, left: 16,  whiteSpace: 'nowrap', textOverflow: 'ellipsis', overflow: 'hidden'}}>
+          <InternalLink to={url}>{ getLegendText(language) } </InternalLink></div>
       </div>
     })}
   </div>

--- a/src/components/ItemDialogContent.js
+++ b/src/components/ItemDialogContent.js
@@ -212,7 +212,7 @@ const chart = function(itemInfo) {
 
   const legend = <div style={{position: 'absolute', width: 170, left: 0, top: 0, marginTop: -5, marginBottom: 5, fontSize: '0.8em'  }}>
     {languages.map(function(language) {
-      const url = language.name === 'Other' ? null : filtersToUrl({grouping: 'language', filters: {language: language.name }});
+      const url = language.name === 'Other' ? null : filtersToUrl({grouping: 'no', filters: {language: language.name }});
       return <div style = {{
         position: 'relative',
         marginTop: 2,

--- a/src/components/ItemDialogContent.js
+++ b/src/components/ItemDialogContent.js
@@ -178,11 +178,11 @@ const chart = function(itemInfo) {
   }; */
   const allLanguages = itemInfo.github_data.languages;
   const languages = (function() {
-    const maxEntries = 8;
+    const maxEntries = 7;
     if (allLanguages.length <= maxEntries) {
       return allLanguages
     } else {
-      return allLanguages.slice(0, maxEntries - 1).concat([{
+      return allLanguages.slice(0, maxEntries).concat([{
         name: 'Other',
         value: _.sum( allLanguages.slice(maxEntries - 1).map( (x) => x.value)),
         color: 'Grey'

--- a/src/reducers/mainReducer.js
+++ b/src/reducers/mainReducer.js
@@ -30,7 +30,7 @@ export const initialState = {
     bestPracticeBadgeId: null,
     enduser: null,
     googlebot: null,
-    language: null,
+    language: undefined, // null means no language
     parents: [],
   },
   grouping: 'relation',

--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -214,6 +214,9 @@ const fields = {
       label: 'No information'
     }),
     filterFn:  function(filter, value, record) {
+      if (filter === null) {
+        return record.language === null;
+      }
       if (!filter) {
         return true;
       }

--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -223,7 +223,7 @@ const fields = {
       if (!(record.github_data || {}).languages) {
         return false;
       }
-      return !! _.find(record.github_data.languages, { name: filter })
+      return !! _.find(record.github_data.languages.slice(0, 7), { name: filter })
     }
   }
 };

--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -208,7 +208,7 @@ const fields = {
   language: {
     id: 'language',
     url: 'language',
-    values: lookups.languages.map( (id) => ({id: id})).concat({
+    values: lookups.languages.map( (id) => ({id: decodeURIComponent(id), url: id})).concat({
       id: null,
       url: 'no',
       label: 'No information'

--- a/src/types/fields.js
+++ b/src/types/fields.js
@@ -208,7 +208,11 @@ const fields = {
   language: {
     id: 'language',
     url: 'language',
-    values: lookups.languages.map( (id) => ({id: id})),
+    values: lookups.languages.map( (id) => ({id: id})).concat({
+      id: null,
+      url: 'no',
+      label: 'No information'
+    }),
     filterFn:  function(filter, value, record) {
       if (!filter) {
         return true;

--- a/src/utils/syncToUrl.js
+++ b/src/utils/syncToUrl.js
@@ -174,7 +174,9 @@ function setFieldFromParams({field, filters, params}) {
   const parts = urlValue.split(',');
   const values = parts.map(function(part) {
     return _.find(fieldInfo.values, function(x) {
-      return x.url.toLowerCase() === part.toLowerCase();
+      const v = x.url.toLowerCase();
+      const p = part.toLowerCase();
+      return v === p || decodeURIComponent(v) === p || qs.parse(decodeURIComponent(v)) === p;
     });
   }).filter(function(x) { return !!x}).map(function(x) {
     return x.id;

--- a/src/utils/syncToUrl.js
+++ b/src/utils/syncToUrl.js
@@ -75,6 +75,7 @@ function addFieldToParams({field, filters, params}) {
   if (_.isUndefined(value)) {
     return;
   }
+  console.info({field, value});
   if (JSON.stringify(value) !== JSON.stringify(initialState.filters[field])) {
     if (!_.isArray(value)) {
       value = [value];

--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -207,6 +207,7 @@ async function main () {
         commitsThisYear: _.sum(((node.github_data || {}).contributions || '').split(';').map( (x) => +x)),
         contributorsCount: (node.github_data || {}).contributors_count,
         contributorsLink: (node.github_data || {}).contributors_link,
+        language: (((node.github_data || {}).languages || [])[0] || {}).name || null,
         stars: (node.github_data || {}).stars,
         license: getLicense(),
         headquarters: getHeadquarters(),
@@ -646,7 +647,7 @@ async function main () {
 
   const generateLanguages = () => {
     const languages = _.flatten(itemsWithExtraFields.map(({github_data}) => ((github_data || {}).languages || []).map( (x) => x.name ) ));
-    return _.uniq(languages);
+    return _.orderBy(_.uniq(languages));
   }
 
   const lookups = {

--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -646,7 +646,7 @@ async function main () {
   }
 
   const generateLanguages = () => {
-    const languages = _.flatten(itemsWithExtraFields.map(({github_data}) => ((github_data || {}).languages || []).map( (x) => x.name ) ));
+    const languages = _.flatten(itemsWithExtraFields.map(({github_data}) => ((github_data || {}).languages || []).map( (x) => encodeURIComponent(x.name) ) ));
     return _.orderBy(_.uniq(languages));
   }
 


### PR DESCRIPTION
@dankohn , please notice this issues:
- in a filter panel, for a grouping select, nothing is selected when a `grouping=language` is used, because you want to hide that option
- we show 'No information' when it is a closed source project or languages are not available by github
- when you filter by a language and also group by a language, you may see that multiple groups are displayed. That is ok, although not obvious from a first glance, because grouping is done by the first language, and filter is done by any language in the project.