### PR TITLE
387 fix ascii filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "esw webpack.config.* src tools --color",
     "lint:watch": "npm run lint -- --watch",
     "update-github-colors": "curl https://raw.githubusercontent.com/Diastro/github-colors/master/github-colors.json > tools/githubColors.json",
-    "fetch": "babel-node tools/validateLandscape && babel-node tools/addExternalInfo.js && npm run yaml2json",
+    "fetch": "babel-node tools/validateLandscape && babel-node tools/checkWrongCharactersInFilenames babel-node tools/addExternalInfo.js && npm run yaml2json",
     "update": "(rm /tmp/landscape.json || true) && babel-node tools/validateLandscape && npm run remove-quotes && LEVEL=medium babel-node tools/addExternalInfo.js && npm run yaml2json && npm run prune && babel-node tools/calculateNumberOfTweets",
     "yaml2json": "babel-node tools/generateJson.js",
     "remove-quotes": "babel-node tools/removeQuotes",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "esw webpack.config.* src tools --color",
     "lint:watch": "npm run lint -- --watch",
     "update-github-colors": "curl https://raw.githubusercontent.com/Diastro/github-colors/master/github-colors.json > tools/githubColors.json",
-    "fetch": "babel-node tools/validateLandscape && babel-node tools/checkWrongCharactersInFilenames babel-node tools/addExternalInfo.js && npm run yaml2json",
+    "fetch": "babel-node tools/validateLandscape && babel-node tools/checkWrongCharactersInFilenames && babel-node tools/addExternalInfo.js && npm run yaml2json",
     "update": "(rm /tmp/landscape.json || true) && babel-node tools/validateLandscape && npm run remove-quotes && LEVEL=medium babel-node tools/addExternalInfo.js && npm run yaml2json && npm run prune && babel-node tools/calculateNumberOfTweets",
     "yaml2json": "babel-node tools/generateJson.js",
     "remove-quotes": "babel-node tools/removeQuotes",

--- a/src/utils/saneName.js
+++ b/src/utils/saneName.js
@@ -1,2 +1,5 @@
+import _ from 'lodash';
 import { paramCase } from 'change-case';
-export default paramCase;
+export default function(x) {
+  return _.deburr(paramCase(x));
+};

--- a/tools/checkWrongCharactersInFilenames.js
+++ b/tools/checkWrongCharactersInFilenames.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import Promise from 'bluebird';
 import { projectPath, settings } from './settings';
+import { dump } from './yaml';
 
 import { hasFatalErrors, setFatalError, reportFatalErrors } from './fatalErrors';
 
@@ -28,14 +29,17 @@ async function main() {
             setFatalError(error);
           }
           else if (logo !== processedLogo) {
-            const error = `FATAL: please rename ${logo} to ${processedLogo}`;
-            console.info(error);
-            setFatalError(error);
+            item.logo = processedLogo;
+            const oldFile = path.resolve(projectPath, 'hosted_logos', logo);
+            const newFile = path.resolve(projectPath, 'hosted_logos', processedLogo);
+            require('fs').renameSync(oldFile, newFile);
+            console.info(`RENAMED: ${logo} => ${processedLogo}`);
           }
         }
       });
     });
   });
+  require('fs').writeFileSync(path.resolve(projectPath, 'landscape.yml'), dump(source));
   if (hasFatalErrors()) {
     await reportFatalErrors();
     process.exit(1);

--- a/tools/fixWrongCharactersInFilenames.js
+++ b/tools/fixWrongCharactersInFilenames.js
@@ -1,0 +1,49 @@
+import _ from 'lodash';
+import path from 'path';
+import Promise from 'bluebird';
+import { projectPath, settings } from './settings';
+import { dump } from './yaml';
+
+import { hasFatalErrors, setFatalError, reportFatalErrors } from './fatalErrors';
+
+function hasNonAscii(str) {
+    return ! /^[\x00-\x7F]*$/.test(str);
+}
+
+
+
+async function main() {
+  const source = require('js-yaml').safeLoad(require('fs').readFileSync(path.resolve(projectPath, 'landscape.yml')));
+  const processedSource = require('js-yaml').safeLoad(require('fs').readFileSync(path.resolve(projectPath, 'processed_landscape.yml')));
+
+  // fix landscape itself with logos
+  _.each(source.landscape, function(category) {
+    _.each(category.subcategories, function(subcategory) {
+      _.each(subcategory.items, function(item) {
+        if (item.logo.startsWith('./hosted_logos')) {
+          const logo = item.logo;
+          const processedLogo = _.deburr(logo);
+          if (hasNonAscii(processedLogo)) {
+            const error = `FATAL: entry ${item.name} has non ascii characters in a logo ${logo}`;
+            console.info(error);
+            setFatalError(error);
+          }
+          else if (logo !== processedLogo) {
+            console.info(`RENAMING: ${logo} to ${processedLogo}`);
+            require('fs').renameSync(path.resolve(projectPath, logo), path.resolve(projectPath, processedLogo));
+            item.logo = processedLogo;
+          }
+        }
+      });
+    });
+  });
+  require('fs').writeFileSync(path.resolve(projectPath, 'landscape.yml'), dump(source));
+  if (hasFatalErrors()) {
+    await reportFatalErrors();
+    process.exit(1);
+  }
+}
+main().catch(function(ex) {
+  console.info(ex);
+  process.exit(1);
+});


### PR DESCRIPTION
I don't want to overengineer this.
This will prevent us from having wrong filenames in hosted_logos. When there are latinic non ascii characters, they will be replaced for cached_logos. If there are cyrillic or chinese symbols in cached_logos, and that happens only if a company name is chinese - we already do not allow such cases.

example error for hosted_logos:
```
Processing the tree
FATAL: please rename LLVMû.svg to LLVMu.svg
```
For omp-landscape, I'll remove  a cached_logo and then I'll commit a new version to the master