### PR TITLE
Fix Firefox resizing

### DIFF
--- a/src/utils/browserZoom.js
+++ b/src/utils/browserZoom.js
@@ -1,6 +1,10 @@
+import isDesktop from './isDesktop';
+
+// This method actually checks if there's zoom on mobile device
+// so it returns false for desktop browsers.
 const isZoomedIn = () => {
-  const scale = window.visualViewport ? visualViewport.scale : screen.width / window.innerWidth;
-  return scale > 1;
+  const { visualViewport } = window
+  return !isDesktop && visualViewport && visualViewport.scale > 1;
 }
 
 export { isZoomedIn };


### PR DESCRIPTION
Fix issues on Firefox when resizing. This was caused by the `isZoomed` function, which calls `window.visualViewport` which is undefined on Firefox. The function is only used to detect "pinched" zoom on mobile, so to fix this, the function will return `false` for desktop browsers.

![ezgif-4-f5bf925bf8d8](https://user-images.githubusercontent.com/16135423/80371961-04c7e280-8893-11ea-8203-da6bcd5d494a.gif)
