### PR TITLE
Automatically calculate optimal full screen size

### DIFF
--- a/src/components/BigPicture/HorizontalCategory.js
+++ b/src/components/BigPicture/HorizontalCategory.js
@@ -40,8 +40,8 @@ const HorizontalCategory = (({ header, subcategories, width, height, top, left, 
         }}
       >
         <div style={{
-          top: 0,
-          bottom: 0,
+          top: 5,
+          bottom: 5,
           left: 0,
           width: categoryTitleHeight,
           position: 'absolute',

--- a/src/components/BigPicture/LandscapeContent.js
+++ b/src/components/BigPicture/LandscapeContent.js
@@ -13,7 +13,7 @@ const extractKeys = (obj, keys) => {
   return _.mapKeys(attributes, (value, key) => _.camelCase(key))
 }
 
-const LandscapeContent = ({groupedItems, onSelectItem, style, zoom, switchToLandscape, landscapeSettings }) => {
+const LandscapeContent = ({groupedItems, onSelectItem, zoom, switchToLandscape, landscapeSettings, padding = 10 }) => {
   const elements = landscapeSettings.elements.map(function(element) {
     if (element.type === 'HorizontalCategory') {
       const cat = _.find(groupedItems, {key: element.category});
@@ -39,12 +39,18 @@ const LandscapeContent = ({groupedItems, onSelectItem, style, zoom, switchToLand
     return null;
   });
 
-  const horizontalMargin = 5
-  const margin = `0 ${horizontalMargin}px`
   const { width, height } = calculateSize(landscapeSettings)
 
-  return <div style={{margin, width: width + horizontalMargin * 2, height: height + 10 }}>
-    <div style={{...style, width, height, transform: `scale(${zoom})`, transformOrigin: '0 0', position: 'relative' }}>
+  const style = {
+    padding,
+    width: width + 2 * padding,
+    height: height + 2 * padding,
+    transform: `scale(${zoom})`,
+    transformOrigin: '0 0'
+  }
+
+  return <div style={style}>
+    <div style={{ position: 'relative' }}>
       {elements}
     </div>
   </div>

--- a/src/components/BigPicture/OtherLandscapeLink.js
+++ b/src/components/BigPicture/OtherLandscapeLink.js
@@ -22,7 +22,7 @@ const OtherLandscapeLink = function({top, left, height, width, color, onClick, t
     return <div style={{position: 'absolute', top, left, height, width, cursor: 'pointer' }} onClick={onClick}>
       <div style={{ width, top: 0, height: 20, lineHeight: '20px', textAlign: 'center', color: 'white', fontSize: 11}}>{title}</div>
       <img loading="lazy" src={`images/${url}_preview.png`} alt={title}
-           style={{ width: width, height: height - 40, objectFit: 'contain', backgroundPosition: 'center', backgroundRepeat: 'no-repeat' }} />
+           style={{ width: width, height: height - 20, objectFit: 'contain', backgroundPosition: 'center', backgroundRepeat: 'no-repeat' }} />
     </div>;
   }
 }

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -7,6 +7,13 @@ $md-screen: 768px;
 $lg-screen: 992px;
 $xl-screen: 1200px;
 
+@media (max-width: $lg-screen) {
+  body, html {
+    overflow: auto;
+    max-height: 100%;
+  }
+}
+
 html {-webkit-text-size-adjust: 100%;}
 .big-picture .zoomed-in {
   overflow: scroll;
@@ -437,7 +444,6 @@ filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='rgb(27,68,108
   height: 100%;
   overflow: scroll;
   -webkit-overflow-scrolling: touch;
-  padding: 10px;
 }
 
 .zoomed-in .landscape-wrapper {

--- a/src/utils/landscapeCalculations.js
+++ b/src/utils/landscapeCalculations.js
@@ -11,6 +11,8 @@ export const subcategoryTitleHeight = 20
 export const dividerWidth = 2
 export const categoryBorder = 1
 export const categoryTitleHeight = 30
+export const outerPadding = 20
+export const headerHeight = 40
 
 // Check if item is large
 const isLargeFn = ({ relation, category, member }) => {

--- a/tools/ciServer.js
+++ b/tools/ciServer.js
@@ -25,6 +25,7 @@ const result = browserSync({
     'src/*.html'
   ],
   ghostMode: false,
+  notify: false,
   middleware: [
     function (req, res, next) {
 

--- a/tools/migrate.js
+++ b/tools/migrate.js
@@ -21,7 +21,7 @@ let newSettings = traverse(settings).map(function () {
     }
 
     if (this.node.type === 'LandscapeLink' && this.node.layout === 'subcategory') {
-      incrementValues(this, {left: -5})
+      incrementValues(this, {left: -5}, false)
     }
 
     if (settings.global.short_name === 'CNCF') {
@@ -130,6 +130,17 @@ let newSettings = traverse(settings).map(function () {
           incrementValues(this, {top: -15})
         }
       }
+    }
+  }
+
+  if (settings.big_picture.main.fullscreen_size && this.node) {
+    if (this.node.fullscreen_size) {
+      const { fullscreen_size, ...attrs } = this.node
+      this.update({ ...attrs })
+    }
+
+    if (this.node.type === 'LandscapeLink' && this.node.layout === 'subcategory') {
+      incrementValues(this, { left: 60, width: -120, height: -20 }, false)
     }
   }
 })


### PR DESCRIPTION
# Description

This is actually two changes in one. The first one is to stop using `fullscreen_size` for any calculations, given that it can be calculated more accurately from the contents of the landscape  
with:

```
width = inner landscape width + 40px padding (20px per side)
height = inner landscape height + 40px padding (20px per side) + 40px for the header

WHERE

inner landscape width = max(category.left + category.width) for all categories
inner landscape height = max(category.top + category.height) for all categories
```

This way of calculating the fullscreen size is preferable because it's accurate and it removes the potential for human error. As you can see below in the Previews section some landscapes had the wrong size and the content didn't fit. Other landscapes had weird margins on the right side  or at the bottom.

The second improvement introduced by this PR is to scale (up) the content of the fullscreen landscape to fit the window. This is to prevent the fullscreen landscape from just utilizing a fraction of the screen on large monitors. Also, once the content is stretched it will be horizontally and vertically centered. Note this feature won't work on Firefox so the content won't be scaled, just centered.

## Previews

Previews are done with the calculations for _width_ and _height_ outlined above. Note how this fixes weird spacing issues or content being clipped.

<table>
<thead>
<tr>
<th>Landscape</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
        <td>cncf-landscape</td>
        <td><img width="300" src="https://landscape.cncf.io/images/landscape_preview.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/cncf/images/landscape_preview.png" /></td>
    <tr>
        <td>cncf-serverless</td>
        <td><img width="300" src="https://landscape.cncf.io/images/serverless.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/cncf/images/serverless_preview.png" /></td>
    <tr>
        <td>cncf-members</td>
        <td><img width="300" src="https://landscape.cncf.io/images/members.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/cncf/images/members_preview.png" /></td>
    <tr>
        <td>lfai</td>
        <td><img width="300" src="https://landscape.lfai.foundation/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/lfai/images/landscape_preview.png" /></td>
    <tr>
        <td>lfedge</td>
        <td><img width="300" src="https://landscape.lfedge.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/lfedge/images/landscape_preview.png" /></td>
    <tr>
        <td>aswf</td>
        <td><img width="300" src="https://landscape.aswf.io/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/aswf/images/landscape_preview.png" /></td>
    <tr>
        <td>graphql</td>
        <td><img width="300" src="https://landscape.graphql.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/graphql/images/landscape_preview.png" /></td>
    <tr>
        <td>omp</td>
        <td><img width="300" src="https://landscape.openmainframeproject.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/omp/images/landscape_preview.png" /></td>
    <tr>
        <td>hl-landscape</td>
        <td><img width="300" src="https://landscape.hyperledger.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/hl-landscape/images/landscape_preview.png" /></td>
    <tr>
        <td>cdf</td>
        <td><img width="300" src="https://landscape.cd.foundation/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/cdf/images/landscape_preview.png" /></td>
    <tr>
        <td>ucf</td>
        <td><img width="300" src="https://landscape.uc.foundation/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/ucf/images/landscape_preview.png" /></td>
    <tr>
        <td>lfenergy</td>
        <td><img width="300" src="https://landscape.lfenergy.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/lfenergy/images/landscape_preview.png" /></td>
    <tr>
        <td>openjsf</td>
        <td><img width="300" src="https://landscape.openjsf.org/images/landscape.png" /></td>
        <td><img width="300" src="https://deploy-preview-556--landscapeapp.netlify.app/openjsf/images/landscape_preview.png" /></td>
</tbody>
    </table>

## Fullscreen (1920x1080)

This section shows how the different landscapes look in a 1920x1080 window. The contents will be stretched to fit the available width and height, so the landscape does not look small compared to the window.

<table>
<thead>
<tr>
<th>Landscape</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<tr>
        <td>cncf-landscape</td>
        <td><img width="300" alt="cncf-landscape-master" src="https://user-images.githubusercontent.com/16135423/82548383-83930100-9b5b-11ea-8397-43027886030f.png" /></td>
        <td><img width="300" alt="cncf-landscape-pr" src="https://user-images.githubusercontent.com/16135423/82548384-842b9780-9b5b-11ea-806c-53725158034d.png" /></td>
    <tr>
        <td>cncf-serverless</td>
        <td><img width="300" alt="cncf-serverless-master" src="https://user-images.githubusercontent.com/16135423/82548396-855cc480-9b5b-11ea-9f8d-dae459fcf256.png" /></td>
        <td><img width="300" alt="cncf-serverless-pr" src="https://user-images.githubusercontent.com/16135423/82548401-85f55b00-9b5b-11ea-81fc-6152671b2046.png" /></td>
    <tr>
        <td>cncf-members</td>
        <td><img width="300" alt="cncf-members-master" src="https://user-images.githubusercontent.com/16135423/82548389-84c42e00-9b5b-11ea-8b3e-821e095645ae.png" /></td>
        <td><img width="300" alt="cncf-members-pr" src="https://user-images.githubusercontent.com/16135423/82548393-855cc480-9b5b-11ea-92ac-9398b6a02d5b.png" /></td>
    <tr>
        <td>lfai</td>
        <td><img width="300" alt="lfai-master" src="https://user-images.githubusercontent.com/16135423/82548409-87268800-9b5b-11ea-8be0-09dfa110b788.png" /></td>
        <td><img width="300" alt="lfai-pr" src="https://user-images.githubusercontent.com/16135423/82548412-87bf1e80-9b5b-11ea-8659-f2f813ccc178.png" /></td>
    <tr>
        <td>lfedge</td>
        <td><img width="300" alt="lfedge-master" src="https://user-images.githubusercontent.com/16135423/82548413-8857b500-9b5b-11ea-91c8-c9d572304253.png" /></td>
        <td><img width="300" alt="lfedge-pr" src="https://user-images.githubusercontent.com/16135423/82548414-8857b500-9b5b-11ea-8925-86fa34a75c99.png" /></td>
    <tr>
        <td>aswf</td>
        <td><img width="300" alt="aswf-master" src="https://user-images.githubusercontent.com/16135423/82548363-7e35b680-9b5b-11ea-983f-b674685b9ece.png" /></td>
        <td><img width="300" alt="aswf-pr" src="https://user-images.githubusercontent.com/16135423/82548370-81c93d80-9b5b-11ea-8c05-f9b8bbe5256a.png" /></td>
    <tr>
        <td>graphql</td>
        <td><img width="300" alt="graphql-master" src="https://user-images.githubusercontent.com/16135423/82548402-85f55b00-9b5b-11ea-8ac9-43353a2aa09b.png" /></td>
        <td><img width="300" alt="graphql-pr" src="https://user-images.githubusercontent.com/16135423/82548404-868df180-9b5b-11ea-8406-a1034ba63919.png" /></td>
    <tr>
        <td>omp</td>
        <td><img width="300" alt="omp-master" src="https://user-images.githubusercontent.com/16135423/82548420-8988e200-9b5b-11ea-8006-712542fcb5e6.png" /></td>
        <td><img width="300" alt="omp-pr" src="https://user-images.githubusercontent.com/16135423/82548422-8988e200-9b5b-11ea-918d-89a003555e4e.png" /></td>
    <tr>
        <td>hl-landscape</td>
        <td><img width="300" alt="hl-landscape-master" src="https://user-images.githubusercontent.com/16135423/82548405-868df180-9b5b-11ea-8b26-c88b42f55c32.png" /></td>
        <td><img width="300" alt="hl-landscape-pr" src="https://user-images.githubusercontent.com/16135423/82548408-87268800-9b5b-11ea-93a6-1127b4f5f24f.png" /></td>
    <tr>
        <td>cdf</td>
        <td><img width="300" alt="cdf-master" src="https://user-images.githubusercontent.com/16135423/82548376-82fa6a80-9b5b-11ea-9053-02e58e50b4a2.png" /></td>
        <td><img width="300" alt="cdf-pr" src="https://user-images.githubusercontent.com/16135423/82548381-82fa6a80-9b5b-11ea-89d4-d24777d70448.png" /></td>
    <tr>
        <td>ucf</td>
        <td><img width="300" alt="ucf-master" src="https://user-images.githubusercontent.com/16135423/82548429-8aba0f00-9b5b-11ea-9102-c7892380258c.png" /></td>
        <td><img width="300" alt="ucf-pr" src="https://user-images.githubusercontent.com/16135423/82548430-8b52a580-9b5b-11ea-8366-15bb908e7bc5.png" /></td>
    <tr>
        <td>lfenergy</td>
        <td><img width="300" alt="lfenergy-master" src="https://user-images.githubusercontent.com/16135423/82548416-88f04b80-9b5b-11ea-8279-3b435171adb7.png" /></td>
        <td><img width="300" alt="lfenergy-pr" src="https://user-images.githubusercontent.com/16135423/82548418-88f04b80-9b5b-11ea-8d62-129111a98877.png" /></td>
    <tr>
        <td>openjsf</td>
        <td><img width="300" alt="openjsf-master" src="https://user-images.githubusercontent.com/16135423/82548425-8a217880-9b5b-11ea-804b-9da9185f786e.png" /></td>
        <td><img width="300" alt="openjsf-pr" src="https://user-images.githubusercontent.com/16135423/82548426-8a217880-9b5b-11ea-8420-7dde8189f2e6.png" /></td>
</tbody>
</table>