### PR TITLE
Search for ticker on Yahoo Finance if getting the quote fails

### DIFF
--- a/tools/apiClients.js
+++ b/tools/apiClients.js
@@ -89,3 +89,7 @@ export const TwitterClient = ApiClient({
     }
   }
 });
+
+export const YahooFinanceClient = ApiClient({
+  baseUrl: 'https://query2.finance.yahoo.com',
+});

--- a/tools/retry.js
+++ b/tools/retry.js
@@ -5,8 +5,13 @@ const retry  = async function (fn, attempts = maxAttempts, delay = 50000, retryS
     const result = await fn();
     return result;
   } catch (ex) {
-    const { statusCode } = ex;
-    console.info(`Attempt #${maxAttempts - attempts + 1}${statusCode ? ` (Status Code: ${statusCode})` : ''}`);
+    const { statusCode, options } = ex;
+    const message = [
+      `Attempt #${maxAttempts - attempts + 1}`,
+      statusCode ? `(Status Code: ${statusCode})` : null,
+      options && options.uri ? `(URI: ${options.uri.split('?')[0]})` : `(MESSAGE: ${ex.message})`
+    ].filter(_ => _).join(' ')
+    console.info(message);
     if (attempts <= 0 || (retryStatuses && !retryStatuses.includes(statusCode))) {
       throw ex;
     }


### PR DESCRIPTION
Change to make the logic for finding a stock market cap smarter. If querying `/quoteSummary/${ticker}` fails, we'll call `/search?q=${ticker}` and use the first result instead to find the market cap.