### PR TITLE
Improvements to npm run update

### DIFF
--- a/landscapes_dev/index.html
+++ b/landscapes_dev/index.html
@@ -27,8 +27,19 @@
     }
 
     td.organization a,
-    td.organization img {
+    td.organization img,
+    .logo {
       height: 30px;
+    }
+
+    .previews {
+      padding-top: 20px;
+    }
+
+    .preview-logo-wrapper {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 4px;
     }
 
     td.status a,
@@ -44,69 +55,122 @@
 </head>
 <body>
   <div class="container is-widescreen">
-    <h1 class="title">Landscapes</h1>
+    <div class="is-clipped">
+      <h1 class="title is-pulled-left">Landscapes</h1>
 
-    <table class="table is-fullwidth">
+      <div class="has-text-link title is-4 is-pulled-right">
+        <a href="#" data-behavior="toggle">View Previews</a>
+        <a href="#" class="is-hidden" data-behavior="toggle">View List</a>
+      </div>
+    </div>
+
+    <table class="table is-fullwidth" data-behavior="toggle-target">
       <thead>
       <th>Organization</th>
       <th>Landscape</th>
       <th>Repo</th>
       <th>Status</th>
       <th>Published</th>
+      <th>Data Refreshed</th>
       </thead>
 
       <tbody></tbody>
     </table>
+
+    <div class="is-hidden previews columns is-multiline" data-behavior="toggle-target"></div>
   </div>
-</div>
 
-<script>
-  const fetchFile = async path => await (await fetch(`https://raw.githubusercontent.com/${path}`)).text()
+  <script>
+    document.addEventListener("DOMContentLoaded", () => {
+      const toggleTargets = document.querySelectorAll('[data-behavior="toggle"], [data-behavior="toggle-target"]')
 
-  const tableEl = document.querySelector("tbody")
+      document.querySelectorAll('[data-behavior="toggle"]').forEach(el => {
+        el.addEventListener('click', e => {
+          e.preventDefault()
+          toggleTargets.forEach(({ classList }) => classList.toggle('is-hidden'))
+        })
+      })
+    })
+  </script>
 
-  const fetchLandscapeInfo = ({ repo, contributors }) => {
-    const rowEl = document.createElement("tr")
-    tableEl.append(rowEl)
-    const appendColumn = (args = {}) => {
-      let column = document.createElement('td')
-      column.setAttribute("class", args.className)
-      column.innerText = "Fetching..."
-      rowEl.append(column)
-      return column
+  <script>
+    const fetchFile = async path => await (await fetch(`https://raw.githubusercontent.com/${path}`)).text()
+
+    const tableEl = document.querySelector("tbody")
+    const previewsEl = document.querySelector(".previews")
+
+    const linkTo = (url, title) => `<a target="_blank" href="${url}">${title}</a>`
+    const imageLinkTo = (url, src, alt) => linkTo(url, `<img src="${src}" alt="${alt}" />`)
+
+    const fetchLandscapeInfo = ({ repo }) => {
+      const rowEl = document.createElement("tr")
+      const dateTimeFormat = new Intl.DateTimeFormat('en', { month: 'short', day: '2-digit', hour: '2-digit', minute:'2-digit' })
+      tableEl.append(rowEl)
+      const appendColumn = (args = {}) => {
+        let column = document.createElement('td')
+        column.setAttribute("class", args.className)
+        column.innerText = "Fetching..."
+        rowEl.append(column)
+        return column
+      }
+
+      const appendPreview = () => {
+        let preview = document.createElement('div')
+        preview.setAttribute("class", "preview column is-one-third-widescreen is-half-desktop is-full-tablet")
+        previewsEl.append(preview)
+        return preview
+      }
+
+      let organizationEl = appendColumn({ className: "organization" })
+      let landscapeEl = appendColumn()
+      let repoEl = appendColumn()
+      let statusEl = appendColumn({ className: "status" })
+      let publishedEl = appendColumn()
+      let updatedEl = appendColumn()
+      let previewEl = appendPreview()
+
+      repoEl.innerHTML = linkTo(`https://github.com/${repo}`, repo)
+
+      fetchFile(`${repo}/master/settings.yml`)
+        .then(settings => {
+          const { company_url, short_name, short_domain, website } = jsyaml.load(settings).global
+          organizationEl.innerHTML = imageLinkTo(company_url, `${website}/images/right-logo.svg`, short_name)
+          landscapeEl.innerHTML = linkTo(website, short_domain)
+          previewEl.innerHTML = `
+              <div class="preview-logo-wrapper">
+                  <img src="${website}/images/right-logo.svg" class="logo" alt="${short_name}"/>
+              </div>
+              ${imageLinkTo(website, `${website}/images/landscape_preview.png`, short_domain)}`
+        })
+
+      fetchFile(`${repo}/master/README.md`)
+        .then(async readme => {
+          const statusUrl = readme.match(/https:\/\/api.netlify.com\/api\/v1\/badges[^)]*/)[0]
+          const deploysUrl = readme.match(/https:\/\/app.netlify.com\/sites[^)]*/)[0]
+          statusEl.innerHTML = `<a href=${deploysUrl}><img src="${statusUrl}" alt="Netlify Status" /></a>`
+
+          const netlifyUrl = statusUrl.replace("badges", "sites").replace("/deploy-status", "")
+          const netlifyInfo = await (await fetch(netlifyUrl)).json()
+          const { published_at } = netlifyInfo.published_deploy
+
+          publishedEl.innerText = dateTimeFormat.format(new Date(published_at))
+        })
+
+      fetchFile(`${repo}/master/processed_landscape.yml`)
+        .then(processedLandscape => {
+          const { updated_at } = jsyaml.load(processedLandscape)
+          const updatedAt = updated_at ? new Date(updated_at) : null
+          const oneDayAgo = new Date() - 24 * 60 * 60 * 1000
+          const className = updatedAt && updatedAt > oneDayAgo ? '' : 'has-text-danger'
+
+          updatedEl.innerHTML = `<div class="${className}">
+              ${updated_at ? dateTimeFormat.format(updatedAt) : 'UNKNOWN'}
+          </div>`
+        })
     }
-    let organizationEl = appendColumn({ className: "organization" })
-    let landscapeEl = appendColumn()
-    let repoEl = appendColumn()
-    let statusEl = appendColumn({ className: "status" })
-    let publishedEl = appendColumn()
 
-    repoEl.innerHTML = `<a href="https://github.com/${repo}">${repo}</a>`
-
-    fetchFile(`${repo}/master/settings.yml`)
-      .then(settings => {
-        const { company_url, short_name, short_domain, website } = jsyaml.load(settings).global
-        organizationEl.innerHTML = `<a href="${company_url}"><img src="${website}/images/right-logo.svg" alt="${short_name}"/></a>`
-        landscapeEl.innerHTML = `<a href="${website}">${short_domain}</a>`
-      })
-
-    fetchFile(`${repo}/master/README.md`)
-      .then(async readme => {
-        const statusUrl = readme.match(/https:\/\/api.netlify.com\/api\/v1\/badges[^)]*/)[0]
-        const deploysUrl = readme.match(/https:\/\/app.netlify.com\/sites[^)]*/)[0]
-        statusEl.innerHTML = `<a href=${deploysUrl}><img src="${statusUrl}" alt="Netlify Status" /></a>`
-
-        const netlifyUrl = statusUrl.replace("badges", "sites").replace("/deploy-status", "")
-        const netlifyInfo = await (await fetch(netlifyUrl)).json()
-        const { published_at } = netlifyInfo.published_deploy
-        const dateTimeFormat = new Intl.DateTimeFormat('en', { month: 'short', day: '2-digit', hour: '2-digit', minute:'2-digit' })
-
-        publishedEl.innerText = dateTimeFormat.format(new Date(published_at))
-      })
-  }
-
-  fetchFile("cncf/landscapeapp/master/landscapes.yml")
-    .then(data => jsyaml.load(data).landscapes.forEach(landscape => fetchLandscapeInfo(landscape)))
-</script>
+    fetchFile("cncf/landscapeapp/master/landscapes.yml")
+      .then(data => jsyaml.load(data).landscapes.forEach(landscape => fetchLandscapeInfo(landscape)))
+  </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "update-github-colors": "curl https://raw.githubusercontent.com/Diastro/github-colors/master/github-colors.json > tools/githubColors.json",
     "migrate": "babel-node tools/migrate",
     "fetch": "babel-node tools/validateLandscape && npm run migrate && babel-node tools/checkWrongCharactersInFilenames && babel-node tools/addExternalInfo.js && npm run yaml2json",
-    "update": "(rm /tmp/landscape.json || true) && babel-node tools/validateLandscape && npm run migrate && npm run remove-quotes && LEVEL=medium babel-node tools/addExternalInfo.js && npm run yaml2json && npm run prune && babel-node tools/calculateNumberOfTweets",
+    "update": "(rm /tmp/landscape.json || true) && babel-node tools/validateLandscape && npm run migrate && npm run remove-quotes && LEVEL=medium babel-node tools/addExternalInfo.js && npm run yaml2json && npm run prune && babel-node tools/calculateNumberOfTweets && babel-node tools/updateTimestamps",
     "yaml2json": "babel-node tools/generateJson.js",
     "remove-quotes": "babel-node tools/removeQuotes",
     "prune": "babel-node tools/pruneExtraEntries",

--- a/tools/addExternalInfo.js
+++ b/tools/addExternalInfo.js
@@ -6,8 +6,6 @@ const source = require('js-yaml').safeLoad(require('fs').readFileSync(path.resol
 const traverse = require('traverse');
 const _ = require('lodash');
 import actualTwitter from './actualTwitter';
-import {dump} from './yaml';
-// import formatCity from '../src/utils/formatCity';
 import { fetchImageEntries, extractSavedImageEntries, removeNonReferencedImages } from './fetchImages';
 import { fetchCrunchbaseEntries, extractSavedCrunchbaseEntries } from './crunchbase';
 import { fetchGithubEntries, extractSavedGithubEntries } from './fetchGithubStats';
@@ -15,6 +13,7 @@ import { fetchStartDateEntries, extractSavedStartDateEntries } from './fetchGith
 import { fetchTwitterEntries, extractSavedTwitterEntries } from './twitter';
 import { fetchBestPracticeEntriesWithFullScan, fetchBestPracticeEntriesWithIndividualUrls, extractSavedBestPracticeEntries } from './fetchBestPractices';
 import shortRepoName from '../src/utils/shortRepoName';
+import updateProcessedLandscape from "./updateProcessedLandscape";
 
 var useCrunchbaseCache = true;
 var useImagesCache=true;
@@ -222,11 +221,12 @@ async function main() {
     }
   });
 
-  newSource.twitter_options = require('js-yaml').safeLoad(require('fs').readFileSync(require('path').resolve(projectPath, 'processed_landscape.yml'))).twitter_options;
+  updateProcessedLandscape(processedLandscape => {
+    const { twitter_options, updated_at } = processedLandscape
 
-  const newContent = "# THIS FILE IS GENERATED AUTOMATICALLY!\n" + dump(newSource);
-  console.info('saving!');
-  require('fs').writeFileSync(path.resolve(projectPath, 'processed_landscape.yml'), newContent);
+    console.info('saving!');
+    return { ...newSource, twitter_options, updated_at }
+  })
 }
 main().catch(function(x) {
   console.info('Reporting exception');

--- a/tools/apiClients.js
+++ b/tools/apiClients.js
@@ -1,7 +1,7 @@
-import Promise from 'bluebird';
 import { env } from 'process';
 import { stringify } from 'query-string';
 import rp from './rpRetry';
+import _ from 'lodash'
 
 ['CRUNCHBASE_KEY', 'GITHUB_KEY', 'TWITTER_KEYS'].forEach((key) => {
   if (!env[key]) {
@@ -12,7 +12,7 @@ import rp from './rpRetry';
 let requests = {};
 
 // We only want to retry a request when rate limited. By default the status code is 429.
-const ApiClient = ({ baseUrl, defaultOptions = {}, defaultParams = {}, retryStatuses = [429] }) => {
+const ApiClient = ({ baseUrl, defaultOptions = {}, defaultParams = {}, retryStatuses = [429], delayFn = null }) => {
   return {
     request: async ({ path = null, url = null, method = 'GET', params = {} }) => {
       const qs = { ...defaultParams, ...params };
@@ -30,7 +30,8 @@ const ApiClient = ({ baseUrl, defaultOptions = {}, defaultParams = {}, retryStat
           json: true,
           ...defaultOptions,
           qs,
-          retryStatuses
+          retryStatuses,
+          delayFn
         })
       }
 
@@ -45,9 +46,20 @@ export const CrunchbaseClient = ApiClient({
   defaultOptions: { followRedirect: true, maxRedirects: 5, timeout: 10 * 1000 }
 });
 
-const OldGithubClient = ApiClient({
+export const GithubClient = ApiClient({
   baseUrl: 'https://api.github.com',
   retryStatuses: [403], // Github returns 403 when rate limiting.
+  delayFn: error => {
+    const rateLimitRemaining = parseInt(_.get(error, ['response', 'headers', 'x-ratelimit-remaining'], 1))
+    const rateLimitReset = parseInt(_.get(error, ['response', 'headers', 'x-ratelimit-reset'], 1)) * 1000
+    if (rateLimitRemaining > 0) {
+      return 30000
+    } else {
+      const delay = Math.ceil((new Date(rateLimitReset)) - (new Date()))
+      console.log(`Hourly rate limit exceeded on Github, delaying for ${Math.round(delay / 1000 / 60)} minutes`)
+      return delay
+    }
+  },
   defaultOptions: {
     followRedirect: true,
     timeout: 10 * 1000,
@@ -57,24 +69,6 @@ const OldGithubClient = ApiClient({
     },
   }
 });
-
-export const GithubClient = {
-  request: async function({ path = null, url = null, method = 'GET', params = {} }) {
-    const rates = await rp({
-      uri: 'https://api.github.com/rate_limit',
-      json: true,
-      headers: {
-        'User-agent': 'CNCF',
-        'Authorization': `token ${env.GITHUB_KEY}`
-      }});
-    const remaining = rates.resources.core.remaining;
-    if (remaining < 100) { // because requests may go in parallel
-      console.info('Pausing for one hour, github quote exceeded');
-      await Promise.delay(3600 * 1000);
-    }
-    return await OldGithubClient.request({path, url, method, params});
-  }
-};
 
 const [consumerKey, consumerSecret, accessTokenKey, accessTokenSecret] = (env.TWITTER_KEYS || '').split(',');
 
@@ -88,4 +82,8 @@ export const TwitterClient = ApiClient({
       access_token_secret: accessTokenSecret
     }
   }
+});
+
+export const YahooFinanceClient = ApiClient({
+  baseUrl: 'https://query2.finance.yahoo.com',
 });

--- a/tools/crunchbase.js
+++ b/tools/crunchbase.js
@@ -1,6 +1,5 @@
 import { setFatalError } from './fatalErrors';
 import colors from 'colors';
-import rp from './rpRetry'
 import Promise from 'bluebird'
 import _ from 'lodash';
 import ensureHttps from './ensureHttps';
@@ -12,7 +11,7 @@ const error = colors.red;
 const fatal = (x) => colors.red(colors.inverse(x));
 const cacheMiss = colors.green;
 const debug = require('debug')('cb');
-import { CrunchbaseClient } from './apiClients';
+import { CrunchbaseClient, YahooFinanceClient } from './apiClients';
 
 export async function getCrunchbaseOrganizationsList() {
   const traverse = require('traverse');
@@ -83,21 +82,18 @@ async function getParentCompanies(companyInfo, visited = []) {
     return [parentInfo].concat(await getParentCompanies(cbInfo, [...visited, permalink]));
   }
 }
+
+const getYahooFinanceData = async ticker => {
+  const response = await YahooFinanceClient.request({ path: `/v10/finance/quoteSummary/${ticker}?modules=summaryDetail` })
+  return _.get(response, ['quoteSummary', 'result', 0, 'summaryDetail', 'marketCap'])
+}
+
 const marketCapCache = {};
 async function getMarketCap(ticker) {
-  // console.info(ticker, stock_exchange);
-  // console.info('ticker is', ticker);
   debug(`Extracting the ticker from ${ticker}`);
-  var quote;
+  let quote;
   try {
-    quote = marketCapCache[ticker];
-    if (!quote) {
-      const response = (await rp({
-        url: `https://query2.finance.yahoo.com/v10/finance/quoteSummary/${ticker}?modules=summaryDetail`,
-        json: true
-      }));
-      quote = response.quoteSummary.result[0].summaryDetail.marketCap;
-    }
+    quote = marketCapCache[ticker] || await getYahooFinanceData(ticker)
   } catch(ex) {
     throw new Error(`Can't resolve stock ticker ${ticker}; please manually add a "stock_ticker" key to landscape.yml or set to null`);
   }

--- a/tools/retry.js
+++ b/tools/retry.js
@@ -1,17 +1,24 @@
 import Promise from 'bluebird';
 const maxAttempts = 5;
-const retry  = async function (fn, attempts = maxAttempts, delay = 50000, retryStatuses = null) {
+const retry  = async function (fn, attempts = maxAttempts, delay = 50000, retryStatuses = [], delayFn = null) {
   try {
     const result = await fn();
     return result;
   } catch (ex) {
-    const { statusCode } = ex;
-    console.info(`Attempt #${maxAttempts - attempts + 1}${statusCode ? ` (Status Code: ${statusCode})` : ''}`);
-    if (attempts <= 0 || (retryStatuses && !retryStatuses.includes(statusCode))) {
+    const { statusCode, options, error } = ex;
+    const message = [
+      `Attempt #${maxAttempts - attempts + 1}`,
+      statusCode ? `(Status Code: ${statusCode})` : null,
+      options && options.uri ? `(URI: ${options.uri.split('?')[0]})` : `(MESSAGE: ${ex.message})`
+    ].filter(_ => _).join(' ')
+    console.info(message);
+    const rateLimitted = retryStatuses.includes(statusCode)
+    const dnsError = error && error.code === 'ENOTFOUND' && error.syscall === 'getaddrinfo'
+    if (attempts <= 0 || (!rateLimitted && !dnsError)) {
       throw ex;
     }
-    await Promise.delay(delay);
-    return await retry(fn, attempts - 1);
+    await Promise.delay(delayFn ? delayFn(ex) : delay);
+    return await retry(fn, attempts - 1, delay, retryStatuses, delayFn);
   }
 }
 export default retry;

--- a/tools/rpRetry.js
+++ b/tools/rpRetry.js
@@ -2,6 +2,7 @@ import retry from './retry';
 import rp from 'request-promise';
 
 const rpWithRetry = async function(args) {
-  return await retry(() => rp(args), 5, 30000, args.retryStatuses);
+  const { retryStatuses, delayFn, ...rest } = args
+  return await retry(() => rp(rest), 5, 30000, retryStatuses, delayFn);
 }
 export default rpWithRetry;

--- a/tools/updateProcessedLandscape.js
+++ b/tools/updateProcessedLandscape.js
@@ -4,10 +4,10 @@ import { resolve } from "path";
 import { safeLoad } from "js-yaml";
 import { dump } from "./yaml";
 
-const updateProcessedLandscape = (callback) => {
+const updateProcessedLandscape = async callback => {
   const path = resolve(projectPath, 'processed_landscape.yml');
   const processedLandscape = existsSync(path) ? safeLoad(readFileSync(path)) : {};
-  const updatedProcessedLandscape = callback(processedLandscape);
+  const updatedProcessedLandscape = await callback(processedLandscape);
   const newContent = "# THIS FILE IS GENERATED AUTOMATICALLY!\n" + dump(updatedProcessedLandscape);
   writeFileSync(path, newContent);
 }

--- a/tools/updateTimestamps.js
+++ b/tools/updateTimestamps.js
@@ -1,0 +1,5 @@
+import updateProcessedLandscape from "./updateProcessedLandscape";
+
+updateProcessedLandscape(processedLandscape => {
+  return { ...processedLandscape, updated_at: new Date() };
+});


### PR DESCRIPTION
Some improvements to the `npm run update` task. Mainly:

* Refactor `GithubClient` to get the rate limit and reset time from the response headers for the latest request, instead of having to query https://api.github.com/rate_limit every time we do a request. Instead of always waiting one hour if we hit the rate limit, this will wait whatever time we have left.
* Add a `YahooFinanceClient` that inherits from `ApiClient`. `ApiClient` allows two things: 1. not repeating a request twice and 2. not retrying a failed request when the failure was not caused by hitting a rate limit. We were retrying requests that were 404 which is unnecessary.
* I've also changed `npm run update` to add `updated_at` to `processed_landscape`. This way we can know when was the latest time that `npm run update` ran successfully. The information will be visible at https://landscapes-dev.netlify.app/