### PR TITLE
Automatically add exchange suffix to stock ticker

### DIFF
--- a/tools/apiClients.js
+++ b/tools/apiClients.js
@@ -13,7 +13,7 @@ import Promise from "bluebird";
 let requests = {};
 
 const maxAttempts = 5
-const delay = 5000
+const delay = 30000
 
 const requestWithRetry = async ({ attempts = maxAttempts, retryStatuses, delayFn, ...rest }) => {
   try {

--- a/tools/crunchbase.js
+++ b/tools/crunchbase.js
@@ -13,6 +13,25 @@ const cacheMiss = colors.green;
 const debug = require('debug')('cb');
 import { CrunchbaseClient, YahooFinanceClient } from './apiClients';
 
+const EXCHANGE_SUFFIXES = {
+  'bit': 'MI', // Milan
+  'epa': 'PA', // Paris
+  'etr': 'DE', // XETRA
+  'hkg': 'HK', // Hong Kong
+  'lse': 'L', // London
+  'moex': 'ME', // Moscow
+  'sse': 'SS', // Shanghai
+  'swx': 'SW', // Zurich
+  'szse': 'SZ',  // Shenzhen
+  'tyo': 'T', // Tokyo
+}
+
+const getSymbolWithSuffix = (symbol, exchange) => {
+  const exchangeSuffix = EXCHANGE_SUFFIXES[exchange]
+
+  return [symbol, exchangeSuffix].filter(_ => _).join('.')
+}
+
 export async function getCrunchbaseOrganizationsList() {
   const traverse = require('traverse');
   const source = require('js-yaml').safeLoad(require('fs').readFileSync(path.resolve(projectPath, 'landscape.yml')));
@@ -135,7 +154,7 @@ export async function fetchData(name) {
   const parentLinks = parents.map( (item) => 'https://www.crunchbase.com/organization/' + item.identifier.permalink );
 
   const firstWithStockSymbol = _.find([result.properties].concat(parents), (x) => !!x.stock_symbol);
-  const stockSymbol = firstWithStockSymbol ? firstWithStockSymbol.stock_symbol.value : undefined;
+  const stockSymbol = firstWithStockSymbol && getSymbolWithSuffix(firstWithStockSymbol.stock_symbol.value, firstWithStockSymbol.stock_exchange_symbol)
   const firstWithTotalFunding = _.find([result.properties].concat(parents), (x) => !!x.funding_total);
   const totalFunding = firstWithTotalFunding ? + firstWithTotalFunding.funding_total.value_usd.toFixed() : undefined;
 


### PR DESCRIPTION
To avoid having to manually fix stock tickers, use the exchange information that crunchbase provides to add the exchange suffix to the stock ticker.

For instance:
* PST becomes [PST.MI](https://finance.yahoo.com/quote/PST.MI)
* VOD becomes [VOD.L](https://finance.yahoo.com/quote/VOD.L)
* 6502 becomes [6502.T](https://finance.yahoo.com/quote/6502.T)
* 0700 becomes [0700.HK](https://finance.yahoo.com/quote/0700.HK)
* 000063 becomes [000063.SZ](https://finance.yahoo.com/quote/000063.SZ)

Note that this method needs to map an exchange provided by crunchbase to a suffix acceptable by Yahoo Finance. So if a new company is added that trades in an exchange we yet don't know, the request will fail until we add a valid mapping.