### PR TITLE
Improvements to finding delisted stocks [Fix #7]

### DIFF
--- a/tools/crunchbase.js
+++ b/tools/crunchbase.js
@@ -117,7 +117,7 @@ async function getMarketCap(ticker) {
   return result;
 }
 
-const isDelisted = entry => !!_.get(entry, ['cards', 'ipos', '0', 'delisted_on', 'value'])
+const isDelisted = entry => !!_.get(entry, ['cards', 'ipos', '0', 'delisted_on'])
 
 const fetchCrunchbaseOrganization = async id => {
   return await CrunchbaseClient.request({


### PR DESCRIPTION
Couple of changes to find a few delisted stocks that were missed (RHT and NOKIA):

```diff
-              ticker: RHT
+              ticker: IBM.SW
```

```diff
-              ticker: NOKIA.HE
```

And to automatically remove null stock tickers when the stock from Crunchbase can actually be found:

```
Deleted null ticker for UCloud Kubernetes Service（UK8S) because the stock exists (688158.SS)
Deleted null ticker for UCloud (KCSP) because the stock exists (688158.SS)
Deleted null ticker for UCloud (member) because the stock exists (688158.SS)
Deleted null ticker for NEC (KCSP) because the stock exists (6701.T)
Deleted null ticker for NEC (member) because the stock exists (6701.T)
Deleted null ticker for Hitachi because the stock exists (6501.T)
Deleted null ticker for Hitachi Vantara (member) because the stock exists (6501.T)
Deleted null ticker for Kingsoft (member) because the stock exists (3888.HK)
Deleted null ticker for HCL Technologies (KCSP) because the stock exists (HCLTECH.NS)
Deleted null ticker for HCL Technologies (member) because the stock exists (HCLTECH.NS)
Deleted null ticker for NCSOFT (member) because the stock exists (036570.KS)
Deleted null ticker for Sugon Cloud Computing (member) because the stock exists (603019.SS)
Deleted null ticker for Dynatrace because the stock exists (DT)
Deleted null ticker for Dynatrace (member) because the stock exists (DT)
```

I've also submitted support requests to Crunchbase to set the right stock ticker for IBM (`NYSE:IBM` instead of `SWX:IBM`) 
