### PR TITLE
Throw error when there's a circular dependency on Crunchbase

### DIFF
--- a/tools/crunchbase.js
+++ b/tools/crunchbase.js
@@ -159,6 +159,10 @@ export async function fetchData(name) {
   let lastOrganization = result;
   while (lastOrganization.cards.parent_organization[0]) {
     const parentOrganization = lastOrganization.cards.parent_organization[0].identifier.permalink
+    if (parents.map(p => p.identifier.permalink).includes(parentOrganization)) {
+      const { permalink } = lastOrganization.properties.identifier
+      throw new Error(`Circular dependency detected: ${permalink} and ${parentOrganization} are parents of each other`)
+    }
     lastOrganization = await fetchCrunchbaseOrganization(parentOrganization)
     parents.push({ ...lastOrganization.properties, delisted: isDelisted(lastOrganization) })
   }
@@ -261,8 +265,8 @@ export async function fetchCrunchbaseEntries({cache, preferCache}) {
         // console.info(c.name);
         addError('crunchbase');
         debug(`normal request failed, and no cached entry for ${c.name}`);
-        setFatalError(`No cached entry, and can not fetch: ${c.name} ` + ex.message.substring(0, 200));
-        errors.push(fatal(`No cached entry, and can not fetch: ${c.name} ` +  ex.message.substring(0, 200)));
+        setFatalError(`No cached entry, and can not fetch: ${c.name}. ` + ex.message.substring(0, 200));
+        errors.push(fatal(`No cached entry, and can not fetch: ${c.name}. ` +  ex.message.substring(0, 200)));
         reporter.write(fatal("F"));
         return null;
       }


### PR DESCRIPTION
Output

```
Fetching crunchbase entries
******************************************************E*************************************************
Using cached entry, because can not fetch: red-hat Circular dependency detected: green-cross-pa-cameca-emeritus-director-keary-d-hayes-ii and danny-hayes-610e are parents of each other
```