### PR TITLE
206 allow to skip crunchbase

### DIFF
--- a/tools/addExternalInfo.js
+++ b/tools/addExternalInfo.js
@@ -118,6 +118,7 @@ async function main() {
     savedCrunchbaseEntries = [];
   } else if (process.env.CRUNCHBASE_KEY_4) {
     console.info('Fetching crunchbase entries');
+    savedCrunchbaseEntries = await extractSavedCrunchbaseEntries();
     crunchbaseEntries = await fetchCrunchbaseEntries({
       cache: savedCrunchbaseEntries,
       preferCache: useCrunchbaseCache});

--- a/tools/apiClients.js
+++ b/tools/apiClients.js
@@ -4,7 +4,7 @@ import requestPromise from 'request-promise';
 import _ from 'lodash'
 import Promise from "bluebird";
 
-['CRUNCHBASE_KEY_4', 'GITHUB_KEY', 'TWITTER_KEYS'].forEach((key) => {
+['GITHUB_KEY', 'TWITTER_KEYS'].forEach((key) => {
   if (!env[key]) {
     console.info(`${key} not provided`);
   }


### PR DESCRIPTION
This adds a global flag `skip_crunchbase` to the `global` section of a `settings.yml`
When a flag is present, usage of `crunchbase` field on item is prohibited, instead an `organization: {name: 'Org Name'}` is a proper way to specify the information about an organization.
Tested on a `test-no-crunchbase` of a finos-landscape

![image](https://user-images.githubusercontent.com/230982/92416089-b9ccae80-f153-11ea-8f19-455d0907f2c8.png)

Example `settings.yml` is https://github.com/finos/finos-landscape/blob/test-no-crunchbase/settings.yml
Example `landscape.yml` is https://github.com/finos/finos-landscape/blob/test-no-crunchbase/landscape.yml , note that we do not use `crunchbase` entries there at all