### PR TITLE
Fix auto-zooming layout issues

### DIFF
--- a/src/components/BigPicture/FullscreenLandscape.js
+++ b/src/components/BigPicture/FullscreenLandscape.js
@@ -12,7 +12,7 @@ const calculateZoom = (width, height, zoomedIn) => {
   const aspectRatio = innerWidth / innerHeight
   const adjustedWidth = outerWidth
   const adjustedHeight = adjustedWidth / aspectRatio
-  let baseZoom = Math.min(adjustedHeight / boxHeight, adjustedWidth / boxWidth).toPrecision(4)
+  let baseZoom = Math.min(adjustedHeight / boxHeight, adjustedWidth / boxWidth, 2).toPrecision(4)
   let wrapperWidth, wrapperHeight
 
   if (baseZoom <= 0.95 || !isDesktop || isFirefox || location.search.indexOf('scale=false') > -1) {


### PR DESCRIPTION
On fullscreen landscape we autozoom the content to fit the window and center the content (this feature works on all browsers except Firefox). 

For very small landscapes the large zoom causes the layout to break. For instance on LFAI

![Screenshot 2020-09-18 at 16 48 11](https://user-images.githubusercontent.com/16135423/93611877-1d19d480-f9cf-11ea-9375-639ce275a8ef.png)

This change limits the maximum amount of zoom, so the layout does not break.

![Screenshot 2020-09-18 at 16 48 21](https://user-images.githubusercontent.com/16135423/93611968-3b7fd000-f9cf-11ea-9265-724099096060.png)


