### PR TITLE
Layout improvements

### DIFF
--- a/src/utils/landscapeCalculations.js
+++ b/src/utils/landscapeCalculations.js
@@ -69,8 +69,10 @@ const calculateHorizontalFixedWidth = ({ subcategories, maxColumns, maxRows, fit
     .sort((a, b) => b.rows - a.rows)
     .forEach((subcategory, idx, collection) => {
       const nextSubcategory = collection[idx + 1]
-      while (availableColumns > 0 && (!nextSubcategory || subcategory.rows >= nextSubcategory.rows)) {
-        subcategory.columns += 1
+      const nextRows = (nextSubcategory && nextSubcategory.rows) || 0
+      const { largeItemsCount } = subcategory
+      while ((availableColumns > 1 || (availableColumns > 0 && subcategory.columns >= largeItemsCount * 2)) && subcategory.rows >= nextRows) {
+        subcategory.columns += subcategory.columns < largeItemsCount * 2 ? 2 : 1
         subcategory.rows =  Math.ceil(subcategory.itemsCount / subcategory.columns)
         availableColumns -= 1
       }


### PR DESCRIPTION
Improvement to calculations done to assign columns to each subcategory, so that subcategories with only large items don't end up with an empty "small" column. This seems to affect only OMP:

Before:
![Screenshot 2020-09-23 at 14 45 36](https://user-images.githubusercontent.com/16135423/94014368-b835f400-fdab-11ea-9e39-af392cc5a0b1.png)

After
![Screenshot 2020-09-23 at 14 45 50](https://user-images.githubusercontent.com/16135423/94014372-b9672100-fdab-11ea-9411-230a532e49cd.png)
