### PR TITLE
Revert "Remove LFN landscape for now"

### DIFF
--- a/landscapes.yml
+++ b/landscapes.yml
@@ -74,3 +74,7 @@ landscapes:
     name: ucf
     repo: ucfoundation/ucf-landscape
     hook: 5d96662e28b476477790dd8a
+  - landscape:
+    name: lfn
+    repo: lfnetworking/member_landscape
+    hook: 60788f5fa3cbd68181e3c209


### PR DESCRIPTION
Now that LFN landscape is building successfully it can be added back.

This reverts commit 1dbe3395432b748a1058f71c54e0d5ea5b6b28e1.