### PR TITLE
Add option to allow duplicate items and repos in landscape

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1146,7 +1146,12 @@ const CncfLandscapeApp = {
     }
 
     const itemsAndHeaders = this.groupedItems.flatMap(groupedItem => {
-      const items = groupedItem.items;
+      const itemsIncludingDuplicates = groupedItem.items;
+      const items = itemsIncludingDuplicates.filter((item, index) => {
+        return itemsIncludingDuplicates.findIndex((firstItem) => {
+          return item['id'] === firstItem['id']
+        }) === index;
+      });
       const cardElements = items.map( (item) => this.cards[item.id].cloneNode(true))
       const buildHeader = function({ header, count, href }) {
         const div = document.createElement('div');


### PR DESCRIPTION
Our Bloomberg landscape often uses the same item in multiple places (which has the same name and repo_url, etc). This Pull Request adds an optional config, `duplicates`, that when set to true enables items to repeated in the landscape without `landscapeapp` raising an error to protect from duplicates.

The duplicates option can be added in the following place in settings.yml:
```
global:
  duplicates: true
```
CC @michaelmoss @awright @danielsilverstone-ct @GeriG966