### PR TITLE
Add option to split 'extra' fields into sections

### DIFF
--- a/src/components/ItemDialogContentRenderer.js
+++ b/src/components/ItemDialogContentRenderer.js
@@ -586,34 +586,53 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
     return '';
   })();
 
+  const renderExtraField = function (key) {
+    if (key.indexOf('summary_') === 0) {
+      return '';
+    }
+    const value = itemInfo.extra[key];
+    const keyText = (function() {
+      const step1 =  key.replace(/_url/g, '');
+      const step2 = step1.split('_').map( (x) => x.charAt(0).toUpperCase() + x.substring(1)).join(' ');
+      return step2;
+    })();
+    const valueText = (function() {
+      if (!!(new Date(value).getTime()) && typeof value === 'string') {
+        return h(relativeDate(new Date(value)));
+      }
+      if (typeof value === 'string' && (value.indexOf('http://') === 0 || value.indexOf('https://') === 0)) {
+        return `<a data-type="external" target=_blank href="${h(value)}">${h(value)}</a>`;
+      }
+      return h(value);
+    })();
+    return `<div class="product-property row">
+      <div class="product-property-name tight-col col-20">${h(keyText)}</div>
+      <div class="product-proerty-value tight-col col-80">${valueText}</div>
+    </div>`;
+  }
+
   const extraElement = ( function() {
     if (!itemInfo.extra) {
       return '';
     }
-    const items = Object.keys(itemInfo.extra).map( function(key) {
-      if (key.indexOf('summary_') === 0) {
-        return '';
-      }
-      const value = itemInfo.extra[key];
-      const keyText = (function() {
-        const step1 =  key.replace(/_url/g, '');
-        const step2 = step1.split('_').map( (x) => x.charAt(0).toUpperCase() + x.substring(1)).join(' ');
-        return step2;
-      })();
-      const valueText = (function() {
-        if (!!(new Date(value).getTime()) && typeof value === 'string') {
-          return h(relativeDate(new Date(value)));
-        }
-        if (typeof value === 'string' && (value.indexOf('http://') === 0 || value.indexOf('https://') === 0)) {
-          return `<a data-type="external" target=_blank href="${h(value)}">${h(value)}</a>`;
-        }
-        return h(value);
-      })();
-      return `<div class="product-property row">
-        <div class="product-property-name tight-col col-20">${h(keyText)}</div>
-        <div class="product-proerty-value tight-col col-80">${valueText}</div>
-      </div>`;
-    });
+    let items = [];
+    const sections = settings.big_picture.main.sections || false;
+    if (!(sections)) {
+      items = Object.keys(itemInfo.extra).filter(key=>itemInfo.extra[key]).map(renderExtraField);
+    } else {
+      items = sections.map( section => {
+        const section_heading = `<div class="product-property row">
+          <div class="product-property-name tight-col col-100" style="font-weight: bold;">${section.name}</div>
+        </div>`;
+        let rows = [section_heading];
+        section.children.forEach( key => {
+          if (itemInfo.extra[key]) {
+            rows.push(renderExtraField(key));
+          }
+        });
+        return rows.length === 1 ? '' : rows.join('');
+      });
+    }
     return items.join('');
   })();
 

--- a/src/components/ItemDialogContentRenderer.js
+++ b/src/components/ItemDialogContentRenderer.js
@@ -620,6 +620,13 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
     if (!(sections)) {
       items = Object.keys(itemInfo.extra).filter(key=>itemInfo.extra[key]).map(renderExtraField);
     } else {
+      Object.keys(itemInfo.extra).forEach( key => {
+        if (sections.every( section => {
+          return !(section.children.includes(key));
+        })) {
+          throw new Error(`Failed to find key "${key}" in any section of the sections object`);
+        }
+      });
       items = sections.map( section => {
         const section_heading = `<div class="product-property row">
           <div class="product-property-name tight-col col-100" style="font-weight: bold;">${section.name}</div>


### PR DESCRIPTION
This adds an optional config in `settings.yml`, which can put the 'extra' fields in an item's dialog box into sections to improve the appearance.

The placement of the `sections` config in `settings.yml` is as follows:
```
big_picture:
  main:
    sections:
      - name: Section1 name
        children:
           - Key1 name in section
           - Key2 name in section
      - name : Section2 name
        children:
          ...
```
This is what the item detail box looks like with and without sections:
Without:
<img width="939" alt="Screenshot 2022-08-04 at 14 37 03" src="https://user-images.githubusercontent.com/47188377/183410084-ee623e37-719f-42e9-871a-e5c23524ddcb.png">

With:
<img width="939" alt="Screenshot 2022-08-04 at 15 34 17" src="https://user-images.githubusercontent.com/47188377/183410118-b045af5f-674c-43b9-8a9f-32cb4b43f759.png">

CC @michaelmoss @awright @danielsilverstone-ct @GeriG966
