### PR TITLE
Stop cards with second_paths being repeated within card mode group

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -1146,7 +1146,12 @@ const CncfLandscapeApp = {
     }
 
     const itemsAndHeaders = this.groupedItems.flatMap(groupedItem => {
-      const items = groupedItem.items;
+      const itemsIncludingDuplicates = groupedItem.items;
+      const items = itemsIncludingDuplicates.filter((item, index) => {
+        return itemsIncludingDuplicates.findIndex((firstItem) => {
+          return item['id'] === firstItem['id']
+        }) === index;
+      });
       const cardElements = items.map( (item) => this.cards[item.id].cloneNode(true))
       const buildHeader = function({ header, count, href }) {
         const div = document.createElement('div');


### PR DESCRIPTION
If an item appears twice in the landscape using the second path variable, this stops it from being repeated in a card mode group (currently it would be repeated multiple times even within a card group).

The item card still shows up in all its different groups when grouping is used.

CC: @michaelmoss @awright @GeriG966 @danielsilverstone-ct @abhi0469