### PR TITLE
Hide twitter button when no twitter key is provided

### DIFF
--- a/src/components/ItemDialogContentRenderer.js
+++ b/src/components/ItemDialogContentRenderer.js
@@ -36,14 +36,18 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
 
   const tweetButton = (function() {
     // locate zoom buttons
-  const twitterUrl = `https://twitter.com/intent/tweet`
 
-  return `<div class="tweet-button">
-    <a data-tweet="true" href="${h(twitterUrl)}">${icons.bird}<span>Tweet</span></a>
+    if (!process.env.TWITTER_KEYS) {
+      return ``
+    }
+    const twitterUrl = `https://twitter.com/intent/tweet`
+
+    return `<div class="tweet-button">
+      <a data-tweet="true" href="${h(twitterUrl)}">${icons.bird}<span>Tweet</span></a>
       <div class="tweet-count-wrapper">
         <div class="tweet-count">${tweetsCount}</div>
-    </div>
-  </div>`
+      </div>
+    </div>`
 
   })();
 


### PR DESCRIPTION
This checks whether there are twitter keys are provided, and if not then hides the twitter button with the tweet count in the dialog box.

CC @michaelmoss @awright @GeriG966 @danielsilverstone-ct @apataru
