### PR TITLE
(URLs): Add configurable setting for self hosted repo url

### DIFF
--- a/src/components/GuideRenderer.js
+++ b/src/components/GuideRenderer.js
@@ -116,13 +116,13 @@ module.exports.render = function({settings, items, guide}) {
   return `
       <div class="links">
         <div>
-          <a href="https://github.com/${settings.global.repo}/edit/${currentBranch}/guide.md" target="_blank">
+          <a href="${(settings.global.self_hosted_repo || false) ? "" : "https://github.com/"}${settings.global.repo}/edit/${currentBranch}/guide.md" target="_blank">
           ${icons.edit}
           Edit this page</a>
         </div>
         <div style="height: 5px;"></div>
           <div>
-          <a href="https://github.com/${settings.global.repo}/issues/new?title=Guide Issue" target="_blank">
+          <a href="${(settings.global.self_hosted_repo || false) ? "" : "https://github.com/"}${settings.global.repo}/issues/new?title=Guide Issue" target="_blank">
             ${icons.github}
           Report issue</a>
         </div>

--- a/src/components/HomePageRenderer.js
+++ b/src/components/HomePageRenderer.js
@@ -189,7 +189,7 @@ module.exports.render = function({settings, guidePayload, hasGuide, bigPictureKe
         <div class="main">
           <div class="disclaimer">
             <span> ${settings.home.header} </span>
-            Please <a data-type="external" target="_blank" href="https://github.com/${settings.global.repo}">open</a> a pull request to
+            Please <a data-type="external" target="_blank" href="${(settings.global.self_hosted_repo || false) ? "" : "https://github.com/"}${settings.global.repo}">open</a> a pull request to
             correct any issues. Greyed logos are not open source. Last Updated: ${process.env.lastUpdated}
           </div>
           <h4 class="summary"></h4>
@@ -226,7 +226,7 @@ module.exports.render = function({settings, guidePayload, hasGuide, bigPictureKe
             width: 100%;
             text-align: center;">
               ${h(settings.home.footer)} For more information, please see the&nbsp;
-            <a data-type="external" target="_blank" eventLabel="crunchbase-terms" href="https://github.com/${settings.global.repo}/blob/HEAD/README.md#license">
+            <a data-type="external" target="_blank" eventLabel="crunchbase-terms" href="${(settings.global.self_hosted_repo || false) ? "" : "https://github.com/"}${settings.global.repo}/blob/HEAD/README.md#license">
                 license
               </a> info.
           </div>


### PR DESCRIPTION
Adds a boolean option `self_hosted_repo` that is set in settings.yml.

This avoids assuming that the git repo url is prefixed with https://github.com , which causes some broken links.

CC @michaelmoss @awright @GeriG966 @danielsilverstone-ct @apataru