### PR TITLE
Add wide option for badges, modularise tag rendering and avoid tag gaps

### DIFF
--- a/src/components/ItemDialogContentRenderer.js
+++ b/src/components/ItemDialogContentRenderer.js
@@ -12,6 +12,7 @@ const icons = require('../utils/icons');
 module.exports.render = function({settings, tweetsCount, itemInfo}) {
 
   const closeUrl = stringifyParams;
+  const wideBadges = settings.big_picture.main.wide_badges || false;
 
   const formatDate = function(x) {
     if (x.text) {
@@ -145,6 +146,17 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
       <span class="tag-name">OpenSSF Best Practices</span>
       <span class="tag-value">${label}</span>
       </a>`);
+  }
+
+  const renderAllTags = function(itemInfo, tweetButton) {
+    const projectTag = renderProjectTag(itemInfo);
+    const parentTag = renderParentTag(itemInfo);
+    const openSourceTag = renderOpenSourceTag(itemInfo.oss);
+    const licenseTag = renderLicenseTag(itemInfo);
+    const badgeTag = renderBadgeTag(itemInfo);
+    return [projectTag, parentTag, openSourceTag, licenseTag, badgeTag, tweetButton].filter(Boolean).map(tag => {
+        return `<div style="${cellStyle}">${tag}</div>`
+    }).join("\n");
   }
 
   const renderChart = function() {
@@ -618,7 +630,7 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
   })();
 
   const cellStyle = `
-    width: 146px;
+    width: ${wideBadges ? "296px" : "146px"};
     marginRight: 4px;
     height: 26px;
     display: inline-block;
@@ -632,12 +644,7 @@ module.exports.render = function({settings, tweetsCount, itemInfo}) {
       </div>
       <div class="product-tags">
         <div class="product-badges" style="width: 300px;" >
-          <div style="${cellStyle}">${renderProjectTag(itemInfo)}</div>
-          <div style="${cellStyle}">${renderParentTag(itemInfo)}</div>
-          <div style="${cellStyle}">${renderOpenSourceTag(itemInfo.oss)}</div>
-          <div style="${cellStyle}">${renderLicenseTag(itemInfo)}</div>
-          <div style="${cellStyle}">${renderBadgeTag(itemInfo)}</div>
-          <div style="${cellStyle}">${tweetButton}</div>
+          ${renderAllTags(itemInfo, tweetButton)}
           <div class="charts-desktop">
             ${renderChart(itemInfo)}
             ${renderParticipation(itemInfo)}


### PR DESCRIPTION
This ensures that there are no gaps when some badges aren't used, by only allocating a div when the badge is in use.

This also adds a boolean setting, `wide_badges`, that can allow the tags on the left handside of the dialog box to be positioned one on top of the other rather than in side by side pairs. This can be useful especially when a badge contains a lot of text.

If `wide_badges` is not set, it is assumed to be false.

The placement of the `wide_badges` config in `settings.yml` is as follows:
```
big_picture:
  main:
    wide_badges: true
          ...
```

CC @michaelmoss @awright @GeriG966 @danielsilverstone-ct @apataru