### PR TITLE
Fix project association on missing global crunchbase

### DIFF
--- a/tools/generateJson.js
+++ b/tools/generateJson.js
@@ -565,7 +565,7 @@ async function main () {
       if (item.member) {
         return {relation: 'member', isSubsidiaryProject: false};
       }
-      if (item.crunchbase === settings.global.self) {
+      if (item.crunchbase === settings.global.self && settings.global.self != null) {
         return {relation: 'member', isSubsidiaryProject: true};
       }
       return {relation: false, isSubsidiaryProject: false};


### PR DESCRIPTION
# Currently behavior

If your landscape doesn't have a crunchbase specified in `config.yml` for `defaultCrunchbase`

Any in `landscape.yml` that also doesn't have a crunchbase (uses `organization` instead) will be marked as a subsidiary

# Expected behavior

Projects are not marked as subsidiaries

